### PR TITLE
Add weekly Saturdays cron and update tagged versions

### DIFF
--- a/.github/workflows/ubi8_multi_arch_image_build.yml
+++ b/.github/workflows/ubi8_multi_arch_image_build.yml
@@ -3,6 +3,8 @@ name: 'UBI 8 multi-arch image build'
 on:
   workflow_dispatch:
   push:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   multiarch-build:
     runs-on: ubuntu-latest
@@ -36,3 +38,9 @@ jobs:
           platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
           push: true
           tags: quay.io/konveyor/builder:latest
+      - name: push tagged version
+        run: |
+          docker tag quay.io/konveyor/builder:latest quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-19)
+          docker tag quay.io/konveyor/builder:latest quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-17)
+          docker push quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-19)
+          docker push quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-17)

--- a/.github/workflows/ubi8_multi_arch_image_build.yml
+++ b/.github/workflows/ubi8_multi_arch_image_build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 6'
 jobs:
   multiarch-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubi9_multi_arch_image_build.yml
+++ b/.github/workflows/ubi9_multi_arch_image_build.yml
@@ -3,6 +3,8 @@ name: 'UBI 9 multi-arch image build'
 on:
   workflow_dispatch:
   push:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   multiarch-build:
     runs-on: ubuntu-latest
@@ -36,3 +38,9 @@ jobs:
           platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
           push: true
           tags: quay.io/konveyor/builder:ubi9-latest
+      - name: push tagged version
+        run: |
+          docker tag quay.io/konveyor/builder:ubi9-latest quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-19)
+          docker tag quay.io/konveyor/builder:ubi9-latest quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-17)
+          docker push quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-19)
+          docker push quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-17)

--- a/.github/workflows/ubi9_multi_arch_image_build.yml
+++ b/.github/workflows/ubi9_multi_arch_image_build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 6'
 jobs:
   multiarch-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
as of this PR, latest would be golang 1.19.4
It would also add the following tags
- v1.19
- v1.19.4
- ubi9-v1.19
- ubi9-v1.19.4