### PR TITLE
Use cached build-push-action to publish v tags instead of `docker tag && docker push`

### DIFF
--- a/.github/workflows/ubi8_multi_arch_image_build.yml
+++ b/.github/workflows/ubi8_multi_arch_image_build.yml
@@ -38,9 +38,22 @@ jobs:
           platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
           push: true
           tags: quay.io/konveyor/builder:latest
-      - name: push tagged version
-        run: |
-          docker tag quay.io/konveyor/builder:latest quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-19)
-          docker tag quay.io/konveyor/builder:latest quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-17)
-          docker push quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-19)
-          docker push quay.io/konveyor/builder:v$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-17)
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: get go version
+        id: go_version_patch
+        run: | 
+          echo "patch_version=$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-19)" >> $GITHUB_ENV
+      - name: get go version
+        id: go_version_minor
+        run: | 
+          echo "minor_version=$(docker run --rm quay.io/konveyor/builder:latest go version | cut -c 14-17)" >> $GITHUB_ENV
+      - name: reuse cache to push tagged Multi-arch images...
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi8
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: true
+          tags: quay.io/konveyor/builder:v${{ env.minor_version }},quay.io/konveyor/builder:v${{ env.patch_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/ubi9_multi_arch_image_build.yml
+++ b/.github/workflows/ubi9_multi_arch_image_build.yml
@@ -38,9 +38,22 @@ jobs:
           platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
           push: true
           tags: quay.io/konveyor/builder:ubi9-latest
-      - name: push tagged version
-        run: |
-          docker tag quay.io/konveyor/builder:ubi9-latest quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-19)
-          docker tag quay.io/konveyor/builder:ubi9-latest quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-17)
-          docker push quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-19)
-          docker push quay.io/konveyor/builder:ubi9-v$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-17)
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - name: get go version
+        id: go_version_patch
+        run: | 
+          echo "patch_version=$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-19)" >> $GITHUB_ENV
+      - name: get go version
+        id: go_version_minor
+        run: | 
+          echo "minor_version=$(docker run --rm quay.io/konveyor/builder:ubi9-latest go version | cut -c 14-17)" >> $GITHUB_ENV
+      - name: reuse cache to push tagged Multi-arch images...
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi9
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: true
+          tags: quay.io/konveyor/builder:ubi9-v${{ env.minor_version }},quay.io/konveyor/builder:ubi9-v${{ env.patch_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
docker tag did not retag every arch from latest manifest-list, only the runner's arch (amd64)