### PR TITLE
Add go 1.20.3 using go install on top of ubi

### DIFF
--- a/.github/workflows/ubi9_multi_arch_image_build_godev.yml
+++ b/.github/workflows/ubi9_multi_arch_image_build_godev.yml
@@ -1,0 +1,86 @@
+name: 'UBI 9 multi-arch go.dev image build'
+ 
+on:
+  workflow_dispatch:
+    inputs:
+      go_version:
+        description: 'Go version to build'
+        required: true
+        default: '1.20.3'
+  push:
+    paths:
+      - 'go.dev.Dockerfile.ubi9'
+      - '.github/workflows/ubi9_multi_arch_image_build_godev.yml'
+  pull_request:
+    paths:
+      - 'go.dev.Dockerfile.ubi9'
+      - '.github/workflows/ubi9_multi_arch_image_build_godev.yml'
+jobs:
+  multiarch-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: add checkout action...
+        uses: actions/checkout@v2
+ 
+      - name: configure QEMU action...
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+ 
+      - name: configure Docker Buildx...
+        id: docker_buildx
+        uses: docker/setup-buildx-action@master
+ 
+      - name: login to Quay.io...
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+          password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+      - name: defining go version to use based on input
+        if: github.event_name == 'workflow_dispatch'
+        run: | 
+          echo "GO_VERSION=${{ github.event.inputs.go_version }}" >> $GITHUB_ENV
+      - name: defining go version to use if no input
+        if: github.event_name != 'workflow_dispatch'
+        run: | 
+          echo "GO_VERSION=1.20.3" >> $GITHUB_ENV
+      - name: build Multi-arch images...
+        uses: docker/build-push-action@v3.3.0
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./go.dev.Dockerfile.ubi9
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: quay.io/konveyor/builder:ubi9-godev${{ env.GO_VERSION }}-latest
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          provenance: false
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_patch
+        run: | 
+          echo "patch_version=$(docker run --rm quay.io/konveyor/builder:ubi9-godev${{ env.GO_VERSION }}-latest go version | cut -c 14-19)" >> $GITHUB_ENV
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_minor
+        run: | 
+          echo "minor_version=$(docker run --rm quay.io/konveyor/builder:ubi9-godev${{ env.GO_VERSION }}-latest go version | cut -c 14-17)" >> $GITHUB_ENV
+      - name: reuse cache to push tagged Multi-arch images...
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v3.3.0
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi9
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: true
+          tags: quay.io/konveyor/builder:ubi9-godev-v${{ env.minor_version }},quay.io/konveyor/builder:ubi9-godev-v${{ env.patch_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          provenance: false

--- a/go.dev.Dockerfile.ubi9
+++ b/go.dev.Dockerfile.ubi9
@@ -1,0 +1,10 @@
+FROM quay.io/konveyor/builder:ubi9-latest AS builder
+# Get golang from go.dev using go install.
+ARG GO_VERSION=1.20.3
+RUN go install golang.org/dl/go${GO_VERSION}@latest
+RUN ${GOPATH}/bin/go${GO_VERSION} download
+RUN mv ${GOPATH}/bin/go${GO_VERSION} /usr/bin/go
+
+#This just makes it easier to switch to/from go-toolset.
+ENV APP_ROOT /opt/app-root
+ENV GOPATH /opt/app-root/src/go


### PR DESCRIPTION
It is possible we will need 1.20.z before it's available in CentOS Appstream.

See:
https://github.com/vmware-tanzu/velero/pull/6143


This PR adds a way to keep almost exactly the same image as current ubi9 builder but replace go version to a newer version.

In addition, the workflow variable should allow for custom new version triggers which we will use on a needed basis.
<img width="330" alt="image" src="https://user-images.githubusercontent.com/11228024/231930785-6a98b87e-c16f-46ed-a43d-aa3a3275a8cc.png">

This new workflow might not be useful to run periodically as the version variable is fixed to a patch version. There will be no go updates by rerunning, other than potentially other packages CVEs.

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>