### PR TITLE
Remove cache-from local to speed up retagging of godev.Dockerfile

### DIFF
--- a/.github/workflows/ubi9_multi_arch_image_build_godev.yml
+++ b/.github/workflows/ubi9_multi_arch_image_build_godev.yml
@@ -58,7 +58,6 @@ jobs:
           platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
           push: ${{ github.event_name != 'pull_request' }}
           tags: quay.io/konveyor/builder:ubi9-godev${{ env.GO_VERSION }}-latest
-          cache-to: type=local,dest=/tmp/.buildx-cache
           provenance: false
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
@@ -82,5 +81,4 @@ jobs:
           platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
           push: true
           tags: quay.io/konveyor/builder:ubi9-godev-v${{ env.minor_version }},quay.io/konveyor/builder:ubi9-godev-v${{ env.patch_version }}
-          cache-from: type=local,src=/tmp/.buildx-cache
           provenance: false


### PR DESCRIPTION
Looks like local cache for this workflow makes the "retagging" step slower. So let's just allow it to cache similarly to prior "latest" step which finishes quickly.