### PR TITLE
Add stream9 image which has FIPS golang 1.20

### DIFF
--- a/.github/workflows/stream9_multi_arch_image_build.yml
+++ b/.github/workflows/stream9_multi_arch_image_build.yml
@@ -1,0 +1,76 @@
+name: 'Stream 9 multi-arch image build'
+ 
+on:
+  workflow_dispatch:
+    # inputs:
+    #   go_version:
+    #     description: 'Go version to build in format X.Y.Z'
+    #     required: false
+    #     default: ''
+  push:
+    paths:
+      - 'Dockerfile.stream9'
+      - '.github/workflows/stream9_multi_arch_image_build.yml'
+  schedule:
+    - cron: '0 0 * * 6'
+  pull_request:
+    paths:
+      - 'Dockerfile.stream9'
+      - '.github/workflows/stream9_multi_arch_image_build.yml'
+jobs:
+  multiarch-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: add checkout action...
+        uses: actions/checkout@v2
+ 
+      - name: configure QEMU action...
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+ 
+      - name: configure Docker Buildx...
+        id: docker_buildx
+        uses: docker/setup-buildx-action@master
+ 
+      - name: login to Quay.io...
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+          password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+ 
+      - name: build Multi-arch images...
+        uses: docker/build-push-action@v3.3.0
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.stream9
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: quay.io/konveyor/builder:stream9-latest
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          provenance: false
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_patch
+        run: | 
+          echo "patch_version=$(docker run --rm quay.io/konveyor/builder:stream9-latest${{ github.event.inputs.go_version }} go version | cut -c 14-19)" >> $GITHUB_ENV
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_minor
+        run: | 
+          echo "minor_version=$(docker run --rm quay.io/konveyor/builder:stream9-latest${{ github.event.inputs.go_version }} go version | cut -c 14-17)" >> $GITHUB_ENV
+      - name: reuse cache to push tagged Multi-arch images...
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v3.3.0
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.stream9
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: true
+          tags: quay.io/konveyor/builder:stream9-v${{ env.minor_version }},quay.io/konveyor/builder:stream9-v${{ env.patch_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          provenance: false

--- a/Dockerfile.stream9
+++ b/Dockerfile.stream9
@@ -1,0 +1,12 @@
+FROM quay.io/centos/centos:stream9 as base
+RUN dnf -y install go git make jq && \
+    dnf clean all
+
+FROM base as builder
+RUN go version
+
+#This just makes it easier to switch to/from go-toolset.
+
+ENV PATH=$PATH:/opt/app-root/src/go/bin
+ENV APP_ROOT /opt/app-root
+ENV GOPATH /opt/app-root/src/go


### PR DESCRIPTION
```
❯ docker run -it --rm quay.io/centos/centos:stream9 sh -c 'dnf install go -yq && go tool nm /usr/bin/go | grep FIPS && go version'

  8cca00 T _cgo_0edd79296193_Cfunc__goboringcrypto_FIPS_mode
  dc1fe0 d crypto/tls.defaultCipherSuitesFIPS
  dc2060 d crypto/tls.defaultFIPSCipherSuitesTLS13
  dc2080 d crypto/tls.defaultFIPSCurvePreferences
  5c50c0 t vendor/github.com/golang-fips/openssl-fips/openssl._Cfunc__goboringcrypto_FIPS_mode.abi0
  dc0ea0 d vendor/github.com/golang-fips/openssl-fips/openssl._cgo_0edd79296193_Cfunc__goboringcrypto_FIPS_mode
  5ce440 t vendor/github.com/golang-fips/openssl-fips/openssl.enableBoringFIPSMode
  e45635 d vendor/github.com/golang-fips/openssl-fips/openssl.strictFIPS
go version go1.20.6 linux/arm64
```

This aligns builder to [more closely resemble that of official UBI 9 Go Toolset](https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant#:~:text=However%2C%20the%20version%20of%20Go%20shipped%20in%20RHEL%20is%20based%20on%20upstream%20Go%27s%20dev.boringcrypto%20branch)