### PR TITLE
Revert "Add artifact metadata storage records to UBI workflows"

### DIFF
--- a/.github/workflows/ubi10_multi_arch_image_build.yml
+++ b/.github/workflows/ubi10_multi_arch_image_build.yml
@@ -43,10 +43,6 @@ jobs:
   multiarch-build:
     needs: determine-versions
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      attestations: write
-      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.determine-versions.outputs.matrix) }}
@@ -72,7 +68,6 @@ jobs:
           password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
 
       - name: build Multi-arch images...
-        id: build
         uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.docker_buildx.outputs.name }}
@@ -85,21 +80,6 @@ jobs:
           provenance: false
           build-args: |
             GO_VERSION=go${{ matrix.go_version }}
-      - name: create artifact storage record for latest image
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/${{ github.repository_owner }}/artifacts/metadata/storage-record \
-            -f name="quay.io/konveyor/builder" \
-            -f digest="${{ steps.build.outputs.digest }}" \
-            -f registry_url="quay.io" \
-            -f artifact_url="quay.io/konveyor/builder:ubi10-latest${{ matrix.go_version }}" \
-            -f status="active"
       - name: get go version
         if: github.event_name != 'pull_request'
         id: go_version_patch
@@ -111,7 +91,6 @@ jobs:
         run: |
           echo "minor_version=$(docker run --rm quay.io/konveyor/builder:ubi10-latest${{ matrix.go_version }} go version | awk '{ print $3 }' | sed -e 's/^go//' | awk -F '.' '{ print $1 "." $2}')" >> $GITHUB_ENV
       - name: reuse cache to push tagged Multi-arch images...
-        id: retag
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v7
         with:
@@ -125,19 +104,3 @@ jobs:
           provenance: false
           build-args: |
             GO_VERSION=go${{ matrix.go_version }}
-      - name: create artifact storage record for tagged images
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/${{ github.repository_owner }}/artifacts/metadata/storage-record \
-            -f name="quay.io/konveyor/builder" \
-            -f digest="${{ steps.retag.outputs.digest }}" \
-            -f registry_url="quay.io" \
-            -f artifact_url="quay.io/konveyor/builder:ubi10-v${{ env.patch_version }}" \
-            -f version="v${{ env.patch_version }}" \
-            -f status="active"

--- a/.github/workflows/ubi8_multi_arch_image_build.yml
+++ b/.github/workflows/ubi8_multi_arch_image_build.yml
@@ -43,10 +43,6 @@ jobs:
   multiarch-build:
     needs: determine-versions
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      attestations: write
-      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.determine-versions.outputs.matrix) }}
@@ -72,7 +68,6 @@ jobs:
           password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
 
       - name: build Multi-arch images...
-        id: build
         uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.docker_buildx.outputs.name }}
@@ -85,21 +80,6 @@ jobs:
           provenance: false
           build-args: |
             GO_VERSION=go${{ matrix.go_version }}
-      - name: create artifact storage record for latest image
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/${{ github.repository_owner }}/artifacts/metadata/storage-record \
-            -f name="quay.io/konveyor/builder" \
-            -f digest="${{ steps.build.outputs.digest }}" \
-            -f registry_url="quay.io" \
-            -f artifact_url="quay.io/konveyor/builder:latest${{ matrix.go_version }}" \
-            -f status="active"
       - name: get go version
         if: github.event_name != 'pull_request'
         id: go_version_patch
@@ -111,7 +91,6 @@ jobs:
         run: |
           echo "minor_version=$(docker run --rm quay.io/konveyor/builder:latest${{ matrix.go_version }} go version | awk '{ print $3 }' | sed -e 's/^go//' | awk -F '.' '{ print $1 "." $2}')" >> $GITHUB_ENV
       - name: reuse cache to push tagged Multi-arch images...
-        id: retag
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v7
         with:
@@ -125,19 +104,3 @@ jobs:
           provenance: false
           build-args: |
             GO_VERSION=go${{ matrix.go_version }}
-      - name: create artifact storage record for tagged images
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/${{ github.repository_owner }}/artifacts/metadata/storage-record \
-            -f name="quay.io/konveyor/builder" \
-            -f digest="${{ steps.retag.outputs.digest }}" \
-            -f registry_url="quay.io" \
-            -f artifact_url="quay.io/konveyor/builder:v${{ env.patch_version }}" \
-            -f version="v${{ env.patch_version }}" \
-            -f status="active"

--- a/.github/workflows/ubi9_multi_arch_image_build.yml
+++ b/.github/workflows/ubi9_multi_arch_image_build.yml
@@ -43,10 +43,6 @@ jobs:
   multiarch-build:
     needs: determine-versions
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      attestations: write
-      id-token: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.determine-versions.outputs.matrix) }}
@@ -72,7 +68,6 @@ jobs:
           password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
 
       - name: build Multi-arch images...
-        id: build
         uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.docker_buildx.outputs.name }}
@@ -85,21 +80,6 @@ jobs:
           provenance: false
           build-args: |
             GO_VERSION=go${{ matrix.go_version }}
-      - name: create artifact storage record for latest image
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/${{ github.repository_owner }}/artifacts/metadata/storage-record \
-            -f name="quay.io/konveyor/builder" \
-            -f digest="${{ steps.build.outputs.digest }}" \
-            -f registry_url="quay.io" \
-            -f artifact_url="quay.io/konveyor/builder:ubi9-latest${{ matrix.go_version }}" \
-            -f status="active"
       - name: get go version
         if: github.event_name != 'pull_request'
         id: go_version_patch
@@ -111,7 +91,6 @@ jobs:
         run: |
           echo "minor_version=$(docker run --rm quay.io/konveyor/builder:ubi9-latest${{ matrix.go_version }} go version | awk '{ print $3 }' | sed -e 's/^go//' | awk -F '.' '{ print $1 "." $2}')" >> $GITHUB_ENV
       - name: reuse cache to push tagged Multi-arch images...
-        id: retag
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v7
         with:
@@ -125,19 +104,3 @@ jobs:
           provenance: false
           build-args: |
             GO_VERSION=go${{ matrix.go_version }}
-      - name: create artifact storage record for tagged images
-        if: github.event_name != 'pull_request'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            /orgs/${{ github.repository_owner }}/artifacts/metadata/storage-record \
-            -f name="quay.io/konveyor/builder" \
-            -f digest="${{ steps.retag.outputs.digest }}" \
-            -f registry_url="quay.io" \
-            -f artifact_url="quay.io/konveyor/builder:ubi9-v${{ env.patch_version }}" \
-            -f version="v${{ env.patch_version }}" \
-            -f status="active"


### PR DESCRIPTION
Reverts konveyor/builder#36

Action was failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD pipeline configuration by removing unnecessary permission declarations and step identifiers from multi-architecture image build workflows.
  * Removed artifact storage record creation steps from image build processes, streamlining the deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->