### PR TITLE
Add OpenSSL FIPS Go builder images for UBI 8, 9, and 10

### DIFF
--- a/.github/workflows/ubi10_openssl_fips_multi_arch_image_build.yml
+++ b/.github/workflows/ubi10_openssl_fips_multi_arch_image_build.yml
@@ -1,0 +1,143 @@
+name: 'UBI 10 OpenSSL FIPS multi-arch image build'
+
+on:
+  workflow_dispatch:
+    inputs:
+      go_version:
+        description: 'Go version to build in format X.Y.Z (matched against golang-fips/go releases)'
+        required: false
+        default: ''
+  push:
+    paths:
+      - 'Dockerfile.ubi10-openssl-fips'
+      - '.github/workflows/ubi10_openssl_fips_multi_arch_image_build.yml'
+  schedule:
+    - cron: '0 2 * * 6'
+  pull_request:
+    paths:
+      - 'Dockerfile.ubi10-openssl-fips'
+      - '.github/workflows/ubi10_openssl_fips_multi_arch_image_build.yml'
+jobs:
+  determine-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Determine Go FIPS versions to build
+        id: set-matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch golang-fips/go releases (newest first from GitHub API)
+          # Uses gh api for authenticated requests (higher rate limit)
+          fips_releases=$(gh api repos/golang-fips/go/releases --paginate)
+
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Get latest release per minor version, take top 2 minor versions
+            # (matching Go's two-release support policy)
+            matrix=$(echo "$fips_releases" | jq -c '
+              [.[] | select(.prerelease == false and .draft == false and (.tag_name | endswith("-openssl-fips"))) | .tag_name] |
+              reduce .[] as $tag (
+                {seen: {}, result: []};
+                ($tag | split("-")[0] | ltrimstr("go") | split(".") | .[0:2] | join(".")) as $minor |
+                if (.seen[$minor] | not) and (.result | length) < 2
+                then .seen[$minor] = true | .result += [$tag]
+                else .
+                end
+              ) | .result |
+              to_entries |
+              map(
+                if .key == 0 then {fips_tag: .value, tag_suffix: ""}
+                else {fips_tag: .value, tag_suffix: (.value | split("-")[0] | ltrimstr("go"))}
+                end
+              ) |
+              {include: .}
+            ')
+          else
+            input_version="${{ github.event.inputs.go_version }}"
+            if [ -n "$input_version" ]; then
+              # Find matching FIPS tag for provided Go version
+              fips_tag=$(echo "$fips_releases" | jq -r --arg v "go${input_version}" \
+                '[.[] | select(.prerelease == false and .draft == false) | .tag_name | select(startswith($v + "-") and endswith("-openssl-fips"))] | sort | last // empty')
+              if [ -z "$fips_tag" ] || [ "$fips_tag" = "null" ]; then
+                echo "ERROR: No golang-fips release found for go${input_version}"
+                exit 1
+              fi
+              matrix=$(jq -nc --arg t "$fips_tag" --arg s "$input_version" '{include: [{fips_tag: $t, tag_suffix: $s}]}')
+            else
+              # Empty input = latest
+              fips_tag=$(echo "$fips_releases" | jq -r \
+                '[.[] | select(.prerelease == false and .draft == false and (.tag_name | endswith("-openssl-fips"))) | .tag_name] | first')
+              matrix=$(jq -nc --arg t "$fips_tag" '{include: [{fips_tag: $t, tag_suffix: ""}]}')
+            fi
+          fi
+          {
+            echo "matrix<<MATRIX_EOF"
+            echo "$matrix"
+            echo "MATRIX_EOF"
+          } >> $GITHUB_OUTPUT
+
+  multiarch-build:
+    needs: determine-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.determine-versions.outputs.matrix) }}
+    steps:
+      - name: add checkout action...
+        uses: actions/checkout@v6
+
+      - name: configure QEMU action...
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: all
+
+      - name: configure Docker Buildx...
+        id: docker_buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: login to Quay.io...
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+          password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+
+      - name: build Multi-arch images...
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi10-openssl-fips
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: quay.io/konveyor/builder:ubi10-openssl-fips-latest${{ matrix.tag_suffix }}
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          provenance: false
+          build-args: |
+            FIPS_TAG=${{ matrix.fips_tag }}
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_patch
+        run: |
+          echo "patch_version=$(docker run --rm quay.io/konveyor/builder:ubi10-openssl-fips-latest${{ matrix.tag_suffix }} go version | awk '{ print $3 }' | sed -e 's/^go//')" >> $GITHUB_ENV
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_minor
+        run: |
+          echo "minor_version=$(docker run --rm quay.io/konveyor/builder:ubi10-openssl-fips-latest${{ matrix.tag_suffix }} go version | awk '{ print $3 }' | sed -e 's/^go//' | awk -F '.' '{ print $1 "." $2}')" >> $GITHUB_ENV
+      - name: reuse cache to push tagged Multi-arch images...
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi10-openssl-fips
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: true
+          tags: quay.io/konveyor/builder:ubi10-openssl-fips-v${{ env.minor_version }},quay.io/konveyor/builder:ubi10-openssl-fips-v${{ env.patch_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          provenance: false
+          build-args: |
+            FIPS_TAG=${{ matrix.fips_tag }}

--- a/.github/workflows/ubi8_openssl_fips_multi_arch_image_build.yml
+++ b/.github/workflows/ubi8_openssl_fips_multi_arch_image_build.yml
@@ -1,0 +1,143 @@
+name: 'UBI 8 OpenSSL FIPS multi-arch image build'
+
+on:
+  workflow_dispatch:
+    inputs:
+      go_version:
+        description: 'Go version to build in format X.Y.Z (matched against golang-fips/go releases)'
+        required: false
+        default: ''
+  push:
+    paths:
+      - 'Dockerfile.ubi8-openssl-fips'
+      - '.github/workflows/ubi8_openssl_fips_multi_arch_image_build.yml'
+  schedule:
+    - cron: '0 2 * * 6'
+  pull_request:
+    paths:
+      - 'Dockerfile.ubi8-openssl-fips'
+      - '.github/workflows/ubi8_openssl_fips_multi_arch_image_build.yml'
+jobs:
+  determine-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Determine Go FIPS versions to build
+        id: set-matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch golang-fips/go releases (newest first from GitHub API)
+          # Uses gh api for authenticated requests (higher rate limit)
+          fips_releases=$(gh api repos/golang-fips/go/releases --paginate)
+
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Get latest release per minor version, take top 2 minor versions
+            # (matching Go's two-release support policy)
+            matrix=$(echo "$fips_releases" | jq -c '
+              [.[] | select(.prerelease == false and .draft == false and (.tag_name | endswith("-openssl-fips"))) | .tag_name] |
+              reduce .[] as $tag (
+                {seen: {}, result: []};
+                ($tag | split("-")[0] | ltrimstr("go") | split(".") | .[0:2] | join(".")) as $minor |
+                if (.seen[$minor] | not) and (.result | length) < 2
+                then .seen[$minor] = true | .result += [$tag]
+                else .
+                end
+              ) | .result |
+              to_entries |
+              map(
+                if .key == 0 then {fips_tag: .value, tag_suffix: ""}
+                else {fips_tag: .value, tag_suffix: (.value | split("-")[0] | ltrimstr("go"))}
+                end
+              ) |
+              {include: .}
+            ')
+          else
+            input_version="${{ github.event.inputs.go_version }}"
+            if [ -n "$input_version" ]; then
+              # Find matching FIPS tag for provided Go version
+              fips_tag=$(echo "$fips_releases" | jq -r --arg v "go${input_version}" \
+                '[.[] | select(.prerelease == false and .draft == false) | .tag_name | select(startswith($v + "-") and endswith("-openssl-fips"))] | sort | last // empty')
+              if [ -z "$fips_tag" ] || [ "$fips_tag" = "null" ]; then
+                echo "ERROR: No golang-fips release found for go${input_version}"
+                exit 1
+              fi
+              matrix=$(jq -nc --arg t "$fips_tag" --arg s "$input_version" '{include: [{fips_tag: $t, tag_suffix: $s}]}')
+            else
+              # Empty input = latest
+              fips_tag=$(echo "$fips_releases" | jq -r \
+                '[.[] | select(.prerelease == false and .draft == false and (.tag_name | endswith("-openssl-fips"))) | .tag_name] | first')
+              matrix=$(jq -nc --arg t "$fips_tag" '{include: [{fips_tag: $t, tag_suffix: ""}]}')
+            fi
+          fi
+          {
+            echo "matrix<<MATRIX_EOF"
+            echo "$matrix"
+            echo "MATRIX_EOF"
+          } >> $GITHUB_OUTPUT
+
+  multiarch-build:
+    needs: determine-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.determine-versions.outputs.matrix) }}
+    steps:
+      - name: add checkout action...
+        uses: actions/checkout@v6
+
+      - name: configure QEMU action...
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: all
+
+      - name: configure Docker Buildx...
+        id: docker_buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: login to Quay.io...
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+          password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+
+      - name: build Multi-arch images...
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi8-openssl-fips
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: quay.io/konveyor/builder:openssl-fips-latest${{ matrix.tag_suffix }}
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          provenance: false
+          build-args: |
+            FIPS_TAG=${{ matrix.fips_tag }}
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_patch
+        run: |
+          echo "patch_version=$(docker run --rm quay.io/konveyor/builder:openssl-fips-latest${{ matrix.tag_suffix }} go version | awk '{ print $3 }' | sed -e 's/^go//')" >> $GITHUB_ENV
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_minor
+        run: |
+          echo "minor_version=$(docker run --rm quay.io/konveyor/builder:openssl-fips-latest${{ matrix.tag_suffix }} go version | awk '{ print $3 }' | sed -e 's/^go//' | awk -F '.' '{ print $1 "." $2}')" >> $GITHUB_ENV
+      - name: reuse cache to push tagged Multi-arch images...
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi8-openssl-fips
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: true
+          tags: quay.io/konveyor/builder:openssl-fips-v${{ env.minor_version }},quay.io/konveyor/builder:openssl-fips-v${{ env.patch_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          provenance: false
+          build-args: |
+            FIPS_TAG=${{ matrix.fips_tag }}

--- a/.github/workflows/ubi9_openssl_fips_multi_arch_image_build.yml
+++ b/.github/workflows/ubi9_openssl_fips_multi_arch_image_build.yml
@@ -1,0 +1,143 @@
+name: 'UBI 9 OpenSSL FIPS multi-arch image build'
+
+on:
+  workflow_dispatch:
+    inputs:
+      go_version:
+        description: 'Go version to build in format X.Y.Z (matched against golang-fips/go releases)'
+        required: false
+        default: ''
+  push:
+    paths:
+      - 'Dockerfile.ubi9-openssl-fips'
+      - '.github/workflows/ubi9_openssl_fips_multi_arch_image_build.yml'
+  schedule:
+    - cron: '0 2 * * 6'
+  pull_request:
+    paths:
+      - 'Dockerfile.ubi9-openssl-fips'
+      - '.github/workflows/ubi9_openssl_fips_multi_arch_image_build.yml'
+jobs:
+  determine-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Determine Go FIPS versions to build
+        id: set-matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch golang-fips/go releases (newest first from GitHub API)
+          # Uses gh api for authenticated requests (higher rate limit)
+          fips_releases=$(gh api repos/golang-fips/go/releases --paginate)
+
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Get latest release per minor version, take top 2 minor versions
+            # (matching Go's two-release support policy)
+            matrix=$(echo "$fips_releases" | jq -c '
+              [.[] | select(.prerelease == false and .draft == false and (.tag_name | endswith("-openssl-fips"))) | .tag_name] |
+              reduce .[] as $tag (
+                {seen: {}, result: []};
+                ($tag | split("-")[0] | ltrimstr("go") | split(".") | .[0:2] | join(".")) as $minor |
+                if (.seen[$minor] | not) and (.result | length) < 2
+                then .seen[$minor] = true | .result += [$tag]
+                else .
+                end
+              ) | .result |
+              to_entries |
+              map(
+                if .key == 0 then {fips_tag: .value, tag_suffix: ""}
+                else {fips_tag: .value, tag_suffix: (.value | split("-")[0] | ltrimstr("go"))}
+                end
+              ) |
+              {include: .}
+            ')
+          else
+            input_version="${{ github.event.inputs.go_version }}"
+            if [ -n "$input_version" ]; then
+              # Find matching FIPS tag for provided Go version
+              fips_tag=$(echo "$fips_releases" | jq -r --arg v "go${input_version}" \
+                '[.[] | select(.prerelease == false and .draft == false) | .tag_name | select(startswith($v + "-") and endswith("-openssl-fips"))] | sort | last // empty')
+              if [ -z "$fips_tag" ] || [ "$fips_tag" = "null" ]; then
+                echo "ERROR: No golang-fips release found for go${input_version}"
+                exit 1
+              fi
+              matrix=$(jq -nc --arg t "$fips_tag" --arg s "$input_version" '{include: [{fips_tag: $t, tag_suffix: $s}]}')
+            else
+              # Empty input = latest
+              fips_tag=$(echo "$fips_releases" | jq -r \
+                '[.[] | select(.prerelease == false and .draft == false and (.tag_name | endswith("-openssl-fips"))) | .tag_name] | first')
+              matrix=$(jq -nc --arg t "$fips_tag" '{include: [{fips_tag: $t, tag_suffix: ""}]}')
+            fi
+          fi
+          {
+            echo "matrix<<MATRIX_EOF"
+            echo "$matrix"
+            echo "MATRIX_EOF"
+          } >> $GITHUB_OUTPUT
+
+  multiarch-build:
+    needs: determine-versions
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.determine-versions.outputs.matrix) }}
+    steps:
+      - name: add checkout action...
+        uses: actions/checkout@v6
+
+      - name: configure QEMU action...
+        uses: docker/setup-qemu-action@v4
+        with:
+          platforms: all
+
+      - name: configure Docker Buildx...
+        id: docker_buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: login to Quay.io...
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+          password: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+
+      - name: build Multi-arch images...
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi9-openssl-fips
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: quay.io/konveyor/builder:ubi9-openssl-fips-latest${{ matrix.tag_suffix }}
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          provenance: false
+          build-args: |
+            FIPS_TAG=${{ matrix.fips_tag }}
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_patch
+        run: |
+          echo "patch_version=$(docker run --rm quay.io/konveyor/builder:ubi9-openssl-fips-latest${{ matrix.tag_suffix }} go version | awk '{ print $3 }' | sed -e 's/^go//')" >> $GITHUB_ENV
+      - name: get go version
+        if: github.event_name != 'pull_request'
+        id: go_version_minor
+        run: |
+          echo "minor_version=$(docker run --rm quay.io/konveyor/builder:ubi9-openssl-fips-latest${{ matrix.tag_suffix }} go version | awk '{ print $3 }' | sed -e 's/^go//' | awk -F '.' '{ print $1 "." $2}')" >> $GITHUB_ENV
+      - name: reuse cache to push tagged Multi-arch images...
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.docker_buildx.outputs.name }}
+          context: .
+          file: ./Dockerfile.ubi9-openssl-fips
+          platforms: linux/amd64,linux/ppc64le,linux/arm64,linux/s390x
+          push: true
+          tags: quay.io/konveyor/builder:ubi9-openssl-fips-v${{ env.minor_version }},quay.io/konveyor/builder:ubi9-openssl-fips-v${{ env.patch_version }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          provenance: false
+          build-args: |
+            FIPS_TAG=${{ matrix.fips_tag }}

--- a/Dockerfile.ubi10-openssl-fips
+++ b/Dockerfile.ubi10-openssl-fips
@@ -1,0 +1,36 @@
+FROM registry.access.redhat.com/ubi10:latest as base
+# gcc + openssl-devel mandatory — CGO required for FIPS/OpenSSL linking
+RUN dnf -y install go git make jq unzip \
+        gcc gcc-c++ openssl-devel perl && \
+    dnf clean all
+
+FROM base as builder
+# FIPS_TAG: e.g. go1.24.2-1-openssl-fips (resolved by workflow, passed as build arg)
+ARG FIPS_TAG=
+RUN set -ex && \
+    if [ -z "$FIPS_TAG" ]; then \
+        echo "ERROR: FIPS_TAG build arg is required" && exit 1; \
+    fi && \
+    echo "FIPS_TAG=$FIPS_TAG" && \
+    export GOROOT_BOOTSTRAP=$(go env GOROOT) && \
+    git config --global user.name "builder" && \
+    git config --global user.email "builder@konveyor.io" && \
+    git clone --depth 1 --branch "$FIPS_TAG" \
+        https://github.com/golang-fips/go.git /tmp/golang-fips && \
+    cd /tmp/golang-fips && \
+    ./scripts/full-initialize-repo.sh && \
+    cd /tmp/golang-fips/go/src && \
+    ./make.bash && \
+    export GOPATH=$(go env GOPATH) && \
+    rm -rf $GOPATH && \
+    rm -f /usr/bin/go && \
+    mkdir -p /opt/app-root/src/ && \
+    mv /tmp/golang-fips/go /opt/app-root/src/go && \
+    rm -rf /tmp/golang-fips && \
+    export PATH=/opt/app-root/src/go/bin:$PATH && \
+    go env && go version
+
+ENV PATH=$PATH:/opt/app-root/src/go/bin
+ENV APP_ROOT /opt/app-root
+ENV GOPATH /opt/app-root/src/go
+ENV GOEXPERIMENT=strictfipsruntime

--- a/Dockerfile.ubi8-openssl-fips
+++ b/Dockerfile.ubi8-openssl-fips
@@ -1,0 +1,36 @@
+FROM registry.access.redhat.com/ubi8:latest as base
+# gcc + openssl-devel mandatory — CGO required for FIPS/OpenSSL linking
+RUN dnf -y install go git make jq unzip \
+        gcc gcc-c++ openssl-devel perl && \
+    dnf clean all
+
+FROM base as builder
+# FIPS_TAG: e.g. go1.24.2-1-openssl-fips (resolved by workflow, passed as build arg)
+ARG FIPS_TAG=
+RUN set -ex && \
+    if [ -z "$FIPS_TAG" ]; then \
+        echo "ERROR: FIPS_TAG build arg is required" && exit 1; \
+    fi && \
+    echo "FIPS_TAG=$FIPS_TAG" && \
+    export GOROOT_BOOTSTRAP=$(go env GOROOT) && \
+    git config --global user.name "builder" && \
+    git config --global user.email "builder@konveyor.io" && \
+    git clone --depth 1 --branch "$FIPS_TAG" \
+        https://github.com/golang-fips/go.git /tmp/golang-fips && \
+    cd /tmp/golang-fips && \
+    ./scripts/full-initialize-repo.sh && \
+    cd /tmp/golang-fips/go/src && \
+    ./make.bash && \
+    export GOPATH=$(go env GOPATH) && \
+    rm -rf $GOPATH && \
+    rm -f /usr/bin/go && \
+    mkdir -p /opt/app-root/src/ && \
+    mv /tmp/golang-fips/go /opt/app-root/src/go && \
+    rm -rf /tmp/golang-fips && \
+    export PATH=/opt/app-root/src/go/bin:$PATH && \
+    go env && go version
+
+ENV PATH=$PATH:/opt/app-root/src/go/bin
+ENV APP_ROOT /opt/app-root
+ENV GOPATH /opt/app-root/src/go
+ENV GOEXPERIMENT=strictfipsruntime

--- a/Dockerfile.ubi9-openssl-fips
+++ b/Dockerfile.ubi9-openssl-fips
@@ -1,0 +1,36 @@
+FROM registry.access.redhat.com/ubi9:latest as base
+# gcc + openssl-devel mandatory — CGO required for FIPS/OpenSSL linking
+RUN dnf -y install go git make jq unzip \
+        gcc gcc-c++ openssl-devel perl && \
+    dnf clean all
+
+FROM base as builder
+# FIPS_TAG: e.g. go1.24.2-1-openssl-fips (resolved by workflow, passed as build arg)
+ARG FIPS_TAG=
+RUN set -ex && \
+    if [ -z "$FIPS_TAG" ]; then \
+        echo "ERROR: FIPS_TAG build arg is required" && exit 1; \
+    fi && \
+    echo "FIPS_TAG=$FIPS_TAG" && \
+    export GOROOT_BOOTSTRAP=$(go env GOROOT) && \
+    git config --global user.name "builder" && \
+    git config --global user.email "builder@konveyor.io" && \
+    git clone --depth 1 --branch "$FIPS_TAG" \
+        https://github.com/golang-fips/go.git /tmp/golang-fips && \
+    cd /tmp/golang-fips && \
+    ./scripts/full-initialize-repo.sh && \
+    cd /tmp/golang-fips/go/src && \
+    ./make.bash && \
+    export GOPATH=$(go env GOPATH) && \
+    rm -rf $GOPATH && \
+    rm -f /usr/bin/go && \
+    mkdir -p /opt/app-root/src/ && \
+    mv /tmp/golang-fips/go /opt/app-root/src/go && \
+    rm -rf /tmp/golang-fips && \
+    export PATH=/opt/app-root/src/go/bin:$PATH && \
+    go env && go version
+
+ENV PATH=$PATH:/opt/app-root/src/go/bin
+ENV APP_ROOT /opt/app-root
+ENV GOPATH /opt/app-root/src/go
+ENV GOEXPERIMENT=strictfipsruntime

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![UBI 8 multi-arch image build](https://github.com/konveyor/builder/actions/workflows/ubi8_multi_arch_image_build.yml/badge.svg)](https://github.com/konveyor/builder/actions/workflows/ubi8_multi_arch_image_build.yml)
 [![UBI 9 multi-arch image build](https://github.com/konveyor/builder/actions/workflows/ubi9_multi_arch_image_build.yml/badge.svg)](https://github.com/konveyor/builder/actions/workflows/ubi9_multi_arch_image_build.yml)
 [![UBI 10 multi-arch image build](https://github.com/konveyor/builder/actions/workflows/ubi10_multi_arch_image_build.yml/badge.svg)](https://github.com/konveyor/builder/actions/workflows/ubi10_multi_arch_image_build.yml)
+[![UBI 8 OpenSSL FIPS multi-arch image build](https://github.com/konveyor/builder/actions/workflows/ubi8_openssl_fips_multi_arch_image_build.yml/badge.svg)](https://github.com/konveyor/builder/actions/workflows/ubi8_openssl_fips_multi_arch_image_build.yml)
+[![UBI 9 OpenSSL FIPS multi-arch image build](https://github.com/konveyor/builder/actions/workflows/ubi9_openssl_fips_multi_arch_image_build.yml/badge.svg)](https://github.com/konveyor/builder/actions/workflows/ubi9_openssl_fips_multi_arch_image_build.yml)
+[![UBI 10 OpenSSL FIPS multi-arch image build](https://github.com/konveyor/builder/actions/workflows/ubi10_openssl_fips_multi_arch_image_build.yml/badge.svg)](https://github.com/konveyor/builder/actions/workflows/ubi10_openssl_fips_multi_arch_image_build.yml)
 
 # Builder
 From time to time we need a newer version of Go to build projects than is available from go-toolset, or other images available on Quay or registry.access.redhat.com.


### PR DESCRIPTION
Build Go from source using golang-fips/go releases with
GOEXPERIMENT=strictfipsruntime for FIPS-compliant crypto via OpenSSL.
Version detection uses golang-fips/go releases API directly to avoid
build failures when upstream Go releases before golang-fips catches up.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

Co-Authored-By: Claude <noreply@anthropic.com>
Co-Authored-By: Happy <yesreply@happy.engineering>
Signed-off-by: Tiger Kaovilai <passawit.kaovilai@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Go toolchain images with OpenSSL FIPS support for Red Hat UBI 8, 9, and 10 with multi-architecture support (amd64, ppc64le, arm64, s390x).
  
* **Chores**
  * Added automated workflows for building and publishing FIPS-enabled builder images.

* **Documentation**
  * Added build status badges for new OpenSSL FIPS multi-arch image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->